### PR TITLE
Bugfix: return empty object for instances missing tags

### DIFF
--- a/flappy_detector/handlers/ingest.py
+++ b/flappy_detector/handlers/ingest.py
@@ -109,7 +109,7 @@ class Ingestor:
                 )
 
                 instance_metadata = {
-                    instance["InstanceId"]: boto3_tags_to_dict(instance["Tags"])
+                    instance["InstanceId"]: boto3_tags_to_dict(instance.get("Tags", {}))
                     for reservation in response["Reservations"]
                     for instance in reservation["Instances"]
                 }

--- a/test-requirements.pip
+++ b/test-requirements.pip
@@ -2,6 +2,7 @@
 pylint
 pycodestyle
 mypy
+types-python-dateutil
 # Testing tools
 nose>=1.1,<2
 nose-cov>=1.5,<2


### PR DESCRIPTION
Ingest was erroring out with a KeyError for Tags on an instance. I'm guessing some instances do not have tags so return an empty dictionary if it does not have any.